### PR TITLE
add listings_live to eddblink

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ What’s Different vs the Original
 - Data model & templates
   - `tradedangerous/templates/TradeDangerous.sql` adds `carrier_docking_access`.
   - One‑time migration: `tradedangerous/templates/database_changes.json` is applied automatically on first run.
-- Repo hygiene
-  - Generated data (`data/`, `*.prices`, `*.db`, caches) stays out of version control.
+- Plugin updates
+  - Added a listings_live option to eddblink so that only live listings can be updated.
 
 The New GUI (td_gui.py)
 -----------------------

--- a/tradedangerous/plugins/eddblink_plug.py
+++ b/tradedangerous/plugins/eddblink_plug.py
@@ -482,15 +482,15 @@ class ImportPlugin(plugins.ImportPluginBase):
         if self.getOption("listings"):
             if self.downloadFile(self.listingsPath) or self.getOption("force"):
                 self.importListings(self.listingsPath)
-                self.tdenv.NOTE("Regenerating .prices file.")
-                cache.regeneratePricesFile(self.tdb, self.tdenv)
 
         if self.getOption("listings_live"):
             if self.downloadFile(self.liveListingsPath) or self.getOption("force"):
                 self.importListings(self.liveListingsPath)
-                self.tdenv.NOTE("Regenerating .prices file.")
-                cache.regeneratePricesFile(self.tdb, self.tdenv)
-        
+
+        if self.getOption("listings") or self.getOption("listings_live"):
+            self.tdenv.NOTE("Regenerating .prices file.")
+            cache.regeneratePricesFile(self.tdb, self.tdenv)
+
         self.tdenv.NOTE("Import completed.")
         
         # TD doesn't need to do anything, tell it to just quit.

--- a/tradedangerous/plugins/eddblink_plug.py
+++ b/tradedangerous/plugins/eddblink_plug.py
@@ -388,11 +388,7 @@ class ImportPlugin(plugins.ImportPluginBase):
             self.options["force"] = True
         
         # Select which options will be updated
-        if self.getOption("listings"):
-            self.options["item"] = True
-            self.options["station"] = True
-
-        if self.getOption("listings_live"):
+        if self.getOption("listings") or self.getOption("listings_live"):
             self.options["item"] = True
             self.options["station"] = True
         

--- a/tradedangerous/plugins/eddblink_plug.py
+++ b/tradedangerous/plugins/eddblink_plug.py
@@ -82,6 +82,7 @@ class ImportPlugin(plugins.ImportPluginBase):
         'shipvend':     "Update ShipVendors using latest file from server. (Implies '-O system,station,ship')",
         'upvend':       "Update UpgradeVendors using latest file from server. (Implies '-O system,station,upgrade')",
         'listings':     "Update market data using latest listings.csv dump. (Implies '-O item,system,station')",
+        'listings_live':"Update market data using latest listings-live.csv dump. (Implies '-O item,system,station')",
         'all':          "Update everything with latest dumpfiles. (Regenerates all tables)",
         'clean':        "Erase entire database and rebuild from empty. (Regenerates all tables.)",
         'skipvend':     "Don't regenerate ShipVendors or UpgradeVendors. (Supercedes '-O all', '-O clean'.)",
@@ -390,6 +391,10 @@ class ImportPlugin(plugins.ImportPluginBase):
         if self.getOption("listings"):
             self.options["item"] = True
             self.options["station"] = True
+
+        if self.getOption("listings_live"):
+            self.options["item"] = True
+            self.options["station"] = True
         
         if self.getOption("shipvend"):
             self.options["ship"] = True
@@ -477,12 +482,14 @@ class ImportPlugin(plugins.ImportPluginBase):
         if self.getOption("listings"):
             if self.downloadFile(self.listingsPath) or self.getOption("force"):
                 self.importListings(self.listingsPath)
+                self.tdenv.NOTE("Regenerating .prices file.")
+                cache.regeneratePricesFile(self.tdb, self.tdenv)
+
+        if self.getOption("listings_live"):
             if self.downloadFile(self.liveListingsPath) or self.getOption("force"):
                 self.importListings(self.liveListingsPath)
-        
-        if self.getOption("listings"):
-            self.tdenv.NOTE("Regenerating .prices file.")
-            cache.regeneratePricesFile(self.tdb, self.tdenv)
+                self.tdenv.NOTE("Regenerating .prices file.")
+                cache.regeneratePricesFile(self.tdb, self.tdenv)
         
         self.tdenv.NOTE("Import completed.")
         


### PR DESCRIPTION
This PR adds a listings_live option to eddblinks, which allows simply updating listings_live data instead of having to tediously wait 15 minutes for the whole listings to update.